### PR TITLE
Added driver name to flow action IDs

### DIFF
--- a/app.json
+++ b/app.json
@@ -11933,7 +11933,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_weekprofile",
+        "id": "HMIP-eTRV-thermostat_set_weekprofile",
         "title": {
           "en": "Set Week Profile"
         },
@@ -11974,7 +11974,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_mode",
+        "id": "HMIP-eTRV-thermostat_set_mode",
         "title": {
           "en": "Set Mode"
         },
@@ -12023,7 +12023,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_weekprofile",
+        "id": "HmIP-eTRV-2-thermostat_set_weekprofile",
         "title": {
           "en": "Set Week Profile"
         },
@@ -12064,7 +12064,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_mode",
+        "id": "HmIP-eTRV-2-thermostat_set_mode",
         "title": {
           "en": "Set Mode"
         },
@@ -12099,7 +12099,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_weekprofile",
+        "id": "HmIP-eTRV-B-thermostat_set_weekprofile",
         "title": {
           "en": "Set Week Profile"
         },
@@ -12140,7 +12140,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_mode",
+        "id": "HmIP-eTRV-B-thermostat_set_mode",
         "title": {
           "en": "Set Mode"
         },
@@ -12175,7 +12175,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_weekprofile",
+        "id": "HmIP-eTRV-C-thermostat_set_weekprofile",
         "title": {
           "en": "Set Week Profile"
         },
@@ -12216,7 +12216,7 @@
         ]
       },
       {
-        "id": "homematic_thermostat_set_mode",
+        "id": "HmIP-eTRV-C-thermostat_set_mode",
         "title": {
           "en": "Set Mode"
         },

--- a/drivers/HMIP-eTRV/driver.flow.compose.json
+++ b/drivers/HMIP-eTRV/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
     "actions": [
         {
-            "id": "homematic_thermostat_set_weekprofile",
+            "id": "HMIP-eTRV-thermostat_set_weekprofile",
             "title": {
                 "en": "Set Week Profile"
             },
@@ -37,7 +37,7 @@
             ]
         },
         {
-            "id": "homematic_thermostat_set_mode",
+            "id": "HMIP-eTRV-thermostat_set_mode",
             "title": {
                 "en": "Set Mode"
             },

--- a/drivers/HMIP-eTRV/driver.js
+++ b/drivers/HMIP-eTRV/driver.js
@@ -18,13 +18,13 @@ class HomematicDriver extends Driver {
         this.homematicTypes = ['HMIP-eTRV'];
         this.log(this.homematicTypes.join(','), 'has been inited');
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_weekprofile')
+        this.homey.flow.getActionCard('HMIP-eTRV-thermostat_set_weekprofile')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_weekprofile', args.weekprofile, {})
 
             })
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_mode')
+        this.homey.flow.getActionCard('HMIP-eTRV-thermostat_set_mode')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_mode', args.mode, {})
 

--- a/drivers/HmIP-eTRV-2/driver.flow.compose.json
+++ b/drivers/HmIP-eTRV-2/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
     "actions": [
         {
-            "id": "homematic_thermostat_set_weekprofile",
+            "id": "HmIP-eTRV-2-thermostat_set_weekprofile",
             "title": {
                 "en": "Set Week Profile"
             },
@@ -37,7 +37,7 @@
             ]
         },
         {
-            "id": "homematic_thermostat_set_mode",
+            "id": "HmIP-eTRV-2-thermostat_set_mode",
             "title": {
                 "en": "Set Mode"
             },

--- a/drivers/HmIP-eTRV-2/driver.js
+++ b/drivers/HmIP-eTRV-2/driver.js
@@ -18,13 +18,13 @@ class HomematicDriver extends Driver {
         this.homematicTypes = ['HmIP-eTRV-2'];
         this.log(this.homematicTypes.join(','), 'has been inited');
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_weekprofile')
+        this.homey.flow.getActionCard('HmIP-eTRV-2-thermostat_set_weekprofile')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_weekprofile', args.weekprofile, {})
 
             })
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_mode')
+        this.homey.flow.getActionCard('HmIP-eTRV-2-thermostat_set_mode')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_mode', args.mode, {})
 

--- a/drivers/HmIP-eTRV-B/driver.flow.compose.json
+++ b/drivers/HmIP-eTRV-B/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
     "actions": [
         {
-            "id": "homematic_thermostat_set_weekprofile",
+            "id": "HmIP-eTRV-B-thermostat_set_weekprofile",
             "title": {
                 "en": "Set Week Profile"
             },
@@ -37,7 +37,7 @@
             ]
         },
         {
-            "id": "homematic_thermostat_set_mode",
+            "id": "HmIP-eTRV-B-thermostat_set_mode",
             "title": {
                 "en": "Set Mode"
             },

--- a/drivers/HmIP-eTRV-B/driver.js
+++ b/drivers/HmIP-eTRV-B/driver.js
@@ -18,13 +18,13 @@ class HomematicDriver extends Driver {
         this.homematicTypes = ['HmIP-eTRV-B'];
         this.log(this.homematicTypes.join(','), 'has been inited');
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_weekprofile')
+        this.homey.flow.getActionCard('HmIP-eTRV-B-thermostat_set_weekprofile')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_weekprofile', args.weekprofile, {})
 
             })
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_mode')
+        this.homey.flow.getActionCard('HmIP-eTRV-B-thermostat_set_mode')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_mode', args.mode, {})
 

--- a/drivers/HmIP-eTRV-C/driver.flow.compose.json
+++ b/drivers/HmIP-eTRV-C/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
     "actions": [
         {
-            "id": "homematic_thermostat_set_weekprofile",
+            "id": "HmIP-eTRV-C-thermostat_set_weekprofile",
             "title": {
                 "en": "Set Week Profile"
             },
@@ -37,7 +37,7 @@
             ]
         },
         {
-            "id": "homematic_thermostat_set_mode",
+            "id": "HmIP-eTRV-C-thermostat_set_mode",
             "title": {
                 "en": "Set Mode"
             },

--- a/drivers/HmIP-eTRV-C/driver.js
+++ b/drivers/HmIP-eTRV-C/driver.js
@@ -18,13 +18,13 @@ class HomematicDriver extends Driver {
         this.homematicTypes = ['HmIP-eTRV-C'];
         this.log(this.homematicTypes.join(','), 'has been inited');
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_weekprofile')
+        this.homey.flow.getActionCard('HmIP-eTRV-C-thermostat_set_weekprofile')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_weekprofile', args.weekprofile, {})
 
             })
 
-        this.homey.flow.getActionCard('homematic_thermostat_set_mode')
+        this.homey.flow.getActionCard('HmIP-eTRV-C-thermostat_set_mode')
             .registerRunListener((args, state) => {
                 return args.device.triggerCapabilityListener('homematic_thermostat_mode', args.mode, {})
 


### PR DESCRIPTION
A new validation in homey-cli complains about duplicated flow action IDs. This pull request fixes that issue by adding the driver names to the action ID like it is also already done for other drivers.