### PR TITLE
Added missing energy.batteries arrays

### DIFF
--- a/app.json
+++ b/app.json
@@ -65,6 +65,12 @@
         "homematic_measure_valve",
         "alarm_battery"
       ],
+      "energy": {
+        "batteries": [
+          "AA",
+          "AA"
+        ]
+      },
       "mobile": {
         "components": [
           {
@@ -4872,6 +4878,12 @@
         "alarm_battery",
         "measure_humidity"
       ],
+      "energy": {
+        "batteries": [
+          "AAA",
+          "AAA"
+        ]
+      },
       "mobile": {
         "components": [
           {

--- a/drivers/HM-CC-RT-DN/driver.compose.json
+++ b/drivers/HM-CC-RT-DN/driver.compose.json
@@ -12,6 +12,9 @@
         "homematic_measure_valve",
         "alarm_battery"
     ],
+    "energy": {
+        "batteries": ["AA", "AA"]
+    },
     "mobile": {
         "components": [
             {

--- a/drivers/HM-TC-IT-WM-W-EU/driver.compose.json
+++ b/drivers/HM-TC-IT-WM-W-EU/driver.compose.json
@@ -13,6 +13,9 @@
         "alarm_battery",
         "measure_humidity"
     ],
+    "energy": {
+        "batteries": ["AAA", "AAA"]
+    },
     "mobile": {
         "components": [
             {


### PR DESCRIPTION
The following drivers define the alarm_battery capability but are missing an array energy.batteries containing the used batteries:
- HM-CC-RT-DN
- HM-TC-IT-WM-W-EU

That causes a validation error. Missing array is added with this pull request.